### PR TITLE
use __slots__ to reduce memory

### DIFF
--- a/bench/benchmark.py
+++ b/bench/benchmark.py
@@ -9,14 +9,14 @@ FILE = pathlib.Path(__file__).absolute().parent / 'weicheng.txt'
 DICT = pathlib.Path(__file__).absolute().parent / 'jieba_dict.txt'
 
 
-def bench(func, round=1):
+def bench(func, round=5):
     t0 = time()
     for _ in range(round):
         with open(FILE, 'r', encoding='utf-8') as f:
             for line in f:
                 list(func(line))
 
-    return time() - t0
+    return (time() - t0) / round
 
 
 if __name__ == '__main__':

--- a/handict/handict.py
+++ b/handict/handict.py
@@ -6,13 +6,14 @@ from .trie import Trie, Word
 
 
 class Chunk:
+    __slots__ = ('words', 'total_len', 'mean', 'var', 'degree')
+
     def __init__(self, words: List[Word]):
         self.words = words
-        self.lens: List[int] = list(map(len, words))
-        self.total_len: int = sum(self.lens)
-        self.num = len(words)
+        lens: List[int] = list(map(len, words))
+        self.total_len: int = sum(lens)
         self.mean = self.total_len / len(words)
-        self.var = -variance(self.lens) if len(words) > 1 else 0
+        self.var = -variance(lens) if len(words) > 1 else 0
         self.degree = sum(log1p(word.freq) for word in words if len(word) == 1)
 
     def __lt__(self, other):

--- a/handict/trie.py
+++ b/handict/trie.py
@@ -3,6 +3,8 @@ from typing import Dict, List, Optional
 
 
 class Word:
+    __slots__ = ('word', 'trans', 'freq')
+
     def __init__(self, word: Optional[str] = None):
         self.word = word
         self.trans: Dict[str, Word] = {}


### PR DESCRIPTION
```
python bench/benchmark.py
Building prefix dict from the default dictionary ...
Loading model from cache /var/folders/wl/k49v127j2bl9rmqnn18nbbqdkf8j7c/T/jieba.cache
Loading model cost 0.553 seconds.
Prefix dict has been built succesfully.
> jieba: 0.9589553833007812
Building trie tree takes 1.5434470176696777s
> handict: 23.098920631408692
```